### PR TITLE
Add auto docstring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Freefuse
-Company project 
+Company project
+
+## Auto Documentation Helper
+
+This repository includes `auto_doc.py`, a simple script that scans a
+Python file and inserts placeholder docstrings for any function lacking
+one. Run it like this:
+
+```bash
+python scripts/auto_doc.py path/to/file.py
+```
+
+A demo file is provided at `scripts/sample.py`.

--- a/scripts/auto_doc.py
+++ b/scripts/auto_doc.py
@@ -1,0 +1,34 @@
+import ast
+import sys
+from typing import Any
+
+class DocstringAdder(ast.NodeTransformer):
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        self.generic_visit(node)
+        if ast.get_docstring(node):
+            return node
+        params = [arg.arg for arg in node.args.args if arg.arg != "self"]
+        lines = [f"{node.name} function.", "", "Parameters:"]
+        if params:
+            lines.extend([f"    {p} (Any): TODO." for p in params])
+        else:
+            lines.append("    None")
+        lines.extend(["", "Returns:", "    TODO."])
+        docstring = "\n".join(lines)
+        node.body.insert(0, ast.Expr(value=ast.Constant(docstring)))
+        return node
+
+def add_docstrings(path: str) -> None:
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read())
+    tree = DocstringAdder().visit(tree)
+    ast.fix_missing_locations(tree)
+    code = ast.unparse(tree)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(code)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python auto_doc.py <python_file>")
+        sys.exit(1)
+    add_docstrings(sys.argv[1])

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -1,0 +1,19 @@
+def process_data(d):
+    """process_data function.
+
+Parameters:
+    d (Any): TODO.
+
+Returns:
+    TODO."""
+    return sorted(set(d))
+
+def calculate_bonus(score):
+    """calculate_bonus function.
+
+Parameters:
+    score (Any): TODO.
+
+Returns:
+    TODO."""
+    return score * 1.1


### PR DESCRIPTION
## Summary
- add a small helper script `auto_doc.py` to insert placeholder docstrings into Python files
- provide a demo file `scripts/sample.py`
- update README with instructions

## Testing
- `python scripts/auto_doc.py scripts/sample.py`


------
https://chatgpt.com/codex/tasks/task_e_6861a0fcb0ec832ba1d2de65212823a6